### PR TITLE
Add interactive onboarding tour for new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-01-30
+
+### Added
+- **Onboarding Tour**: New contextual onboarding tooltips guide first-time users through key features:
+  - Adding team members
+  - Clicking cards to edit
+  - Dragging cards to reposition
+  - Connecting cards to set manager relationships
+- **Smart Tour Behavior**: Tour pauses and resumes based on canvas state (waits for cards to exist, pauses if cards are deleted)
+- **Connection Handle Hover Effect**: Handles grow from 8px to 12px on hover for better discoverability
+- **Grab Cursor**: Cards now show grab/grabbing cursor to indicate draggability
+
+### Changed
+- **Improved Handle Visibility**: Connection handles are more discoverable with size increase on hover
+- **Designer Type Badge**: Now hidden when no type is selected (instead of showing empty badge)
+- **Viewport Auto-fit**: During onboarding, viewport automatically adjusts when cards are added
+
+### Technical
+- Onboarding state persisted in localStorage
+- Tooltips stay within viewport bounds (clamped to edges)
+- Tooltip z-index set below panels so users can still interact with settings/editor
+
 ## [0.2.0] - 2026-01-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "design-team-map",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "design-team-map",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@xyflow/react": "^12.10.0",
         "html2canvas": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "design-team-map",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Toolbar from './components/Toolbar';
 import SidePanel from './components/panels/SidePanel';
 import SettingsPanel from './components/panels/SettingsPanel';
 import Toast from './components/Toast';
+import Onboarding from './components/Onboarding';
 import styles from './App.module.css';
 
 function App() {
@@ -15,6 +16,7 @@ function App() {
       <SidePanel />
       <SettingsPanel />
       <Toast />
+      <Onboarding />
     </div>
   );
 }

--- a/src/components/FlowChart.tsx
+++ b/src/components/FlowChart.tsx
@@ -160,14 +160,22 @@ function FlowChartInner() {
     setEdges(flowEdges);
   }, [flowEdges, setEdges]);
 
-  // Fit view only on initial mount or when first nodes are added
+  // Fit view when nodes are added
   useEffect(() => {
+    const nodesIncreased = teamNodes.length > prevNodeCount.current;
+    const onboardingActive = !localStorage.getItem('design-team-map-onboarding-completed');
+
     if (isInitialMount.current && teamNodes.length > 0) {
       // Small delay to ensure nodes are rendered
       setTimeout(() => {
         fitView({ padding: 0.2, duration: 200 });
       }, 100);
       isInitialMount.current = false;
+    } else if (nodesIncreased && onboardingActive) {
+      // During onboarding, fit view whenever cards are added
+      setTimeout(() => {
+        fitView({ padding: 0.2, duration: 200 });
+      }, 100);
     } else if (prevNodeCount.current === 0 && teamNodes.length > 0) {
       // First nodes added after empty state
       setTimeout(() => {

--- a/src/components/Onboarding.module.css
+++ b/src/components/Onboarding.module.css
@@ -67,9 +67,6 @@
 }
 
 .header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   margin-bottom: var(--space-2);
 }
 
@@ -77,11 +74,6 @@
   font-weight: 600;
   color: var(--text-primary);
   font-size: 14px;
-}
-
-.stepCount {
-  font-size: 11px;
-  color: var(--text-muted);
 }
 
 .content {

--- a/src/components/Onboarding.module.css
+++ b/src/components/Onboarding.module.css
@@ -1,22 +1,3 @@
-.overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-  z-index: 1000;
-  pointer-events: none;
-}
-
-.spotlight {
-  position: fixed;
-  border-radius: var(--border-radius);
-  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
-  pointer-events: none;
-  transition: all 0.3s ease;
-}
-
 .tooltip {
   position: fixed;
   width: 280px;
@@ -24,19 +5,16 @@
   border-radius: var(--border-radius);
   box-shadow: var(--shadow-lg);
   padding: var(--space-3);
-  pointer-events: auto;
   z-index: 1001;
-  animation: tooltipFadeIn 0.2s ease-out;
+  animation: tooltipFadeIn 0.4s ease-out;
 }
 
 @keyframes tooltipFadeIn {
   from {
     opacity: 0;
-    transform: translateY(8px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 

--- a/src/components/Onboarding.module.css
+++ b/src/components/Onboarding.module.css
@@ -6,7 +6,7 @@
   border-radius: var(--border-radius);
   box-shadow: var(--shadow-lg);
   padding: var(--space-3);
-  z-index: 1001;
+  z-index: 50; /* Below panels (100+) so users can interact with editor/settings */
   animation: tooltipFadeIn 0.4s ease-out;
 }
 

--- a/src/components/Onboarding.module.css
+++ b/src/components/Onboarding.module.css
@@ -2,6 +2,7 @@
   position: fixed;
   width: 280px;
   background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: var(--border-radius);
   box-shadow: var(--shadow-lg);
   padding: var(--space-3);
@@ -16,6 +17,53 @@
   to {
     opacity: 1;
   }
+}
+
+/* Arrow styles */
+.tooltip::before {
+  content: '';
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  transform: rotate(45deg);
+}
+
+/* Arrow pointing up (tooltip is below target) */
+.arrowBottom::before {
+  top: -7px;
+  left: 50%;
+  margin-left: -6px;
+  border-right: none;
+  border-bottom: none;
+}
+
+/* Arrow pointing down (tooltip is above target) */
+.arrowTop::before {
+  bottom: -7px;
+  left: 50%;
+  margin-left: -6px;
+  border-left: none;
+  border-top: none;
+}
+
+/* Arrow pointing left (tooltip is to the right of target) */
+.arrowRight::before {
+  left: -7px;
+  top: 50%;
+  margin-top: -6px;
+  border-right: none;
+  border-top: none;
+}
+
+/* Arrow pointing right (tooltip is to the left of target) */
+.arrowLeft::before {
+  right: -7px;
+  top: 50%;
+  margin-top: -6px;
+  border-left: none;
+  border-bottom: none;
 }
 
 .header {

--- a/src/components/Onboarding.module.css
+++ b/src/components/Onboarding.module.css
@@ -72,7 +72,7 @@
 }
 
 .skipBtn {
-  padding: var(--space-1) var(--space-2);
+  padding: 0;
   background: none;
   border: none;
   color: var(--text-muted);
@@ -89,7 +89,7 @@
   padding: var(--space-1) var(--space-3);
   background-color: var(--primary);
   border: none;
-  border-radius: var(--border-radius-sm);
+  border-radius: var(--border-radius);
   color: white;
   font-size: 12px;
   font-weight: 500;

--- a/src/components/Onboarding.module.css
+++ b/src/components/Onboarding.module.css
@@ -1,0 +1,102 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.spotlight {
+  position: fixed;
+  border-radius: var(--border-radius);
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  transition: all 0.3s ease;
+}
+
+.tooltip {
+  position: fixed;
+  width: 280px;
+  background-color: var(--bg-secondary);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-3);
+  pointer-events: auto;
+  z-index: 1001;
+  animation: tooltipFadeIn 0.2s ease-out;
+}
+
+@keyframes tooltipFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-2);
+}
+
+.title {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.stepCount {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.content {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0 0 var(--space-3) 0;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.skipBtn {
+  padding: var(--space-1) var(--space-2);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.skipBtn:hover {
+  color: var(--text-secondary);
+}
+
+.nextBtn {
+  padding: var(--space-1) var(--space-3);
+  background-color: var(--primary);
+  border: none;
+  border-radius: var(--border-radius-sm);
+  color: white;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.nextBtn:hover {
+  background-color: var(--primary-hover);
+}

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -36,7 +36,7 @@ const steps: OnboardingStep[] = [
     minCards: 1,
   },
   {
-    target: '.react-flow__node',
+    target: '.react-flow__node:nth-of-type(2)',
     title: 'Connect to Set Manager',
     content: 'Drag between handles to connect cards, or use the Manager dropdown in the editor panel.',
     position: 'top',

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -76,11 +76,15 @@ export default function Onboarding() {
     return () => clearTimeout(timer);
   }, []);
 
-  // When cards are added and we're waiting, show the tour
+  // When cards are added and we're waiting, show the tour after a delay
   useEffect(() => {
     if (waitingForCard && hasCards) {
       setWaitingForCard(false);
-      setIsVisible(true);
+      // Delay to let the card render and user see it
+      const timer = setTimeout(() => {
+        setIsVisible(true);
+      }, 1000);
+      return () => clearTimeout(timer);
     }
   }, [waitingForCard, hasCards]);
 
@@ -150,34 +154,21 @@ export default function Onboarding() {
   const tooltipStyle = getTooltipPosition(targetRect, step.position);
 
   return (
-    <div className={styles.overlay}>
-      {targetRect && (
-        <div
-          className={styles.spotlight}
-          style={{
-            top: targetRect.top - 4,
-            left: targetRect.left - 4,
-            width: targetRect.width + 8,
-            height: targetRect.height + 8,
-          }}
-        />
-      )}
-      <div className={styles.tooltip} style={tooltipStyle}>
-        <div className={styles.header}>
-          <span className={styles.title}>{step.title}</span>
-          <span className={styles.stepCount}>
-            {currentStep + 1} / {steps.length}
-          </span>
-        </div>
-        <p className={styles.content}>{step.content}</p>
-        <div className={styles.actions}>
-          <button className={styles.skipBtn} onClick={handleSkip}>
-            Skip Tour
-          </button>
-          <button className={styles.nextBtn} onClick={handleNext}>
-            {currentStep < steps.length - 1 ? 'Next' : 'Got it!'}
-          </button>
-        </div>
+    <div className={styles.tooltip} style={tooltipStyle}>
+      <div className={styles.header}>
+        <span className={styles.title}>{step.title}</span>
+        <span className={styles.stepCount}>
+          {currentStep + 1} / {steps.length}
+        </span>
+      </div>
+      <p className={styles.content}>{step.content}</p>
+      <div className={styles.actions}>
+        <button className={styles.skipBtn} onClick={handleSkip}>
+          Skip Tour
+        </button>
+        <button className={styles.nextBtn} onClick={handleNext}>
+          {currentStep < steps.length - 1 ? 'Next' : 'Got it!'}
+        </button>
       </div>
     </div>
   );

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -36,10 +36,10 @@ const steps: OnboardingStep[] = [
     requiresCard: true,
   },
   {
-    target: '.react-flow__handle',
+    target: '.react-flow__node',
     title: 'Connect to Set Manager',
     content: 'Drag from the bottom handle of a manager to the top handle of a report to create reporting relationships.',
-    position: 'bottom',
+    position: 'top',
     requiresCard: true,
   },
 ];

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -199,9 +199,6 @@ export default function Onboarding() {
     <div className={`${styles.tooltip} ${arrowClass}`} style={tooltipStyle}>
       <div className={styles.header}>
         <span className={styles.title}>{step.title}</span>
-        <span className={styles.stepCount}>
-          {currentStep + 1} / {steps.length}
-        </span>
       </div>
       <p className={styles.content}>{step.content}</p>
       <div className={styles.actions}>
@@ -209,7 +206,7 @@ export default function Onboarding() {
           Skip Tour
         </button>
         <button className={styles.nextBtn} onClick={handleNext}>
-          {currentStep < steps.length - 1 ? 'Next' : 'Got it!'}
+          Ok
         </button>
       </div>
     </div>

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -113,6 +113,19 @@ export default function Onboarding() {
     };
   }, [waitingForCards, hasEnoughCards]);
 
+  // Pause tour if cards are deleted and we no longer have enough
+  useEffect(() => {
+    const completed = localStorage.getItem(ONBOARDING_KEY);
+    if (completed) return;
+
+    // If tooltip is visible but we don't have enough cards anymore, pause
+    if (isVisible && !hasEnoughCards) {
+      console.log('[Onboarding] cards deleted, pausing tour - need', currentStepMinCards, 'have', cardCount);
+      setIsVisible(false);
+      setWaitingForCards(true);
+    }
+  }, [isVisible, hasEnoughCards, currentStepMinCards, cardCount]);
+
   // Find and update target element position
   useEffect(() => {
     if (!isVisible) return;

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -1,0 +1,174 @@
+import { useState, useEffect } from 'react';
+import styles from './Onboarding.module.css';
+
+const ONBOARDING_KEY = 'design-team-map-onboarding-completed';
+
+interface OnboardingStep {
+  target: string;
+  title: string;
+  content: string;
+  position: 'top' | 'bottom' | 'left' | 'right';
+}
+
+const steps: OnboardingStep[] = [
+  {
+    target: '[data-testid="add-member-btn"]',
+    title: 'Add Team Members',
+    content: 'Click here to add new team members or planned hires to your org chart.',
+    position: 'bottom',
+  },
+  {
+    target: '.react-flow__node',
+    title: 'Click to Edit',
+    content: 'Click any card to select it and edit details in the side panel.',
+    position: 'right',
+  },
+  {
+    target: '.react-flow__node',
+    title: 'Drag to Move',
+    content: 'Grab the grip handle (⋮⋮) or anywhere on the card to drag and reposition it.',
+    position: 'bottom',
+  },
+  {
+    target: '.react-flow__handle',
+    title: 'Connect to Set Manager',
+    content: 'Drag from the bottom handle of a manager to the top handle of a report to create reporting relationships.',
+    position: 'bottom',
+  },
+];
+
+export default function Onboarding() {
+  const [isVisible, setIsVisible] = useState(false);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
+
+  useEffect(() => {
+    const completed = localStorage.getItem(ONBOARDING_KEY);
+    if (!completed) {
+      // Delay to allow the app to render first
+      const timer = setTimeout(() => {
+        setIsVisible(true);
+      }, 1000);
+      return () => clearTimeout(timer);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isVisible) return;
+
+    const findTarget = () => {
+      const step = steps[currentStep];
+      const element = document.querySelector(step.target);
+      if (element) {
+        setTargetRect(element.getBoundingClientRect());
+      } else {
+        setTargetRect(null);
+      }
+    };
+
+    findTarget();
+    // Re-calculate on resize/scroll
+    window.addEventListener('resize', findTarget);
+    window.addEventListener('scroll', findTarget, true);
+
+    return () => {
+      window.removeEventListener('resize', findTarget);
+      window.removeEventListener('scroll', findTarget, true);
+    };
+  }, [isVisible, currentStep]);
+
+  const handleNext = () => {
+    if (currentStep < steps.length - 1) {
+      setCurrentStep(currentStep + 1);
+    } else {
+      handleComplete();
+    }
+  };
+
+  const handleSkip = () => {
+    handleComplete();
+  };
+
+  const handleComplete = () => {
+    localStorage.setItem(ONBOARDING_KEY, 'true');
+    setIsVisible(false);
+  };
+
+  if (!isVisible) return null;
+
+  const step = steps[currentStep];
+  const tooltipStyle = getTooltipPosition(targetRect, step.position);
+
+  return (
+    <div className={styles.overlay}>
+      {targetRect && (
+        <div
+          className={styles.spotlight}
+          style={{
+            top: targetRect.top - 4,
+            left: targetRect.left - 4,
+            width: targetRect.width + 8,
+            height: targetRect.height + 8,
+          }}
+        />
+      )}
+      <div className={styles.tooltip} style={tooltipStyle}>
+        <div className={styles.header}>
+          <span className={styles.title}>{step.title}</span>
+          <span className={styles.stepCount}>
+            {currentStep + 1} / {steps.length}
+          </span>
+        </div>
+        <p className={styles.content}>{step.content}</p>
+        <div className={styles.actions}>
+          <button className={styles.skipBtn} onClick={handleSkip}>
+            Skip Tour
+          </button>
+          <button className={styles.nextBtn} onClick={handleNext}>
+            {currentStep < steps.length - 1 ? 'Next' : 'Got it!'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function getTooltipPosition(
+  targetRect: DOMRect | null,
+  position: OnboardingStep['position']
+): React.CSSProperties {
+  if (!targetRect) {
+    return {
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+    };
+  }
+
+  const offset = 12;
+  const tooltipWidth = 280;
+  const tooltipHeight = 150;
+
+  switch (position) {
+    case 'bottom':
+      return {
+        top: targetRect.bottom + offset,
+        left: targetRect.left + targetRect.width / 2 - tooltipWidth / 2,
+      };
+    case 'top':
+      return {
+        top: targetRect.top - tooltipHeight - offset,
+        left: targetRect.left + targetRect.width / 2 - tooltipWidth / 2,
+      };
+    case 'right':
+      return {
+        top: targetRect.top + targetRect.height / 2 - tooltipHeight / 2,
+        left: targetRect.right + offset,
+      };
+    case 'left':
+      return {
+        top: targetRect.top + targetRect.height / 2 - tooltipHeight / 2,
+        left: targetRect.left - tooltipWidth - offset,
+      };
+  }
+}

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -104,7 +104,7 @@ export default function Onboarding() {
       console.log('[Onboarding] delay complete, showing tooltip');
       setWaitingForCards(false);
       setIsVisible(true);
-    }, 1500);
+    }, 1000);
 
     return () => {
       if (timerRef.current) {
@@ -218,27 +218,33 @@ function getTooltipPosition(
   const offset = 16; // Increased offset for arrow space
   const tooltipWidth = 280;
   const tooltipHeight = 150;
+  const padding = 16; // Minimum padding from viewport edges
+
+  let top: number;
+  let left: number;
 
   switch (position) {
     case 'bottom':
-      return {
-        top: targetRect.bottom + offset,
-        left: targetRect.left + targetRect.width / 2 - tooltipWidth / 2,
-      };
+      top = targetRect.bottom + offset;
+      left = targetRect.left + targetRect.width / 2 - tooltipWidth / 2;
+      break;
     case 'top':
-      return {
-        top: targetRect.top - tooltipHeight - offset - 20, // Extra space so card is visible
-        left: targetRect.left + targetRect.width / 2 - tooltipWidth / 2,
-      };
+      top = targetRect.top - tooltipHeight - offset - 20; // Extra space so card is visible
+      left = targetRect.left + targetRect.width / 2 - tooltipWidth / 2;
+      break;
     case 'right':
-      return {
-        top: targetRect.top + targetRect.height / 2 - tooltipHeight / 2,
-        left: targetRect.right + offset,
-      };
+      top = targetRect.top + targetRect.height / 2 - tooltipHeight / 2;
+      left = targetRect.right + offset;
+      break;
     case 'left':
-      return {
-        top: targetRect.top + targetRect.height / 2 - tooltipHeight / 2,
-        left: targetRect.left - tooltipWidth - offset,
-      };
+      top = targetRect.top + targetRect.height / 2 - tooltipHeight / 2;
+      left = targetRect.left - tooltipWidth - offset;
+      break;
   }
+
+  // Clamp to viewport bounds
+  top = Math.max(padding, Math.min(top, window.innerHeight - tooltipHeight - padding));
+  left = Math.max(padding, Math.min(left, window.innerWidth - tooltipWidth - padding));
+
+  return { top, left };
 }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -105,6 +105,7 @@ export default function Toolbar() {
           <button
             className="btn btn-primary"
             onClick={() => setShowAddMenu(!showAddMenu)}
+            data-testid="add-member-btn"
           >
             + Add
           </button>

--- a/src/components/nodes/TeamMemberNode.module.css
+++ b/src/components/nodes/TeamMemberNode.module.css
@@ -48,7 +48,7 @@
 .header {
   display: flex;
   align-items: center;
-  gap: var(--space-1);
+  justify-content: space-between;
   padding: var(--space-1) var(--space-2);
   border-radius: calc(var(--border-radius) - 2px) calc(var(--border-radius) - 2px) 0 0;
   font-size: 10px;
@@ -57,26 +57,8 @@
   letter-spacing: 0.5px;
 }
 
-.dragHandle {
-  color: var(--gray-500);
-  font-size: 8px;
-  letter-spacing: -2px;
-  opacity: 0.6;
-  transition: opacity 0.15s ease;
-  cursor: grab;
-}
-
-.dragHandle:active {
-  cursor: grabbing;
-}
-
-.node:hover .dragHandle {
-  opacity: 1;
-}
-
 .level {
   color: var(--gray-800);
-  flex: 1;
 }
 
 .type {

--- a/src/components/nodes/TeamMemberNode.module.css
+++ b/src/components/nodes/TeamMemberNode.module.css
@@ -139,8 +139,11 @@
   height: 8px !important;
   background-color: var(--gray-300) !important;
   border: 2px solid var(--bg-secondary) !important;
+  transition: all 0.15s ease;
 }
 
 .handle:hover {
+  width: 12px !important;
+  height: 12px !important;
   background-color: var(--primary) !important;
 }

--- a/src/components/nodes/TeamMemberNode.module.css
+++ b/src/components/nodes/TeamMemberNode.module.css
@@ -5,9 +5,13 @@
   min-width: 160px;
   max-width: 200px;
   box-shadow: var(--shadow);
-  cursor: pointer;
+  cursor: grab;
   transition: box-shadow 0.15s ease, transform 0.15s ease;
   position: relative;
+}
+
+.node:active {
+  cursor: grabbing;
 }
 
 .node:hover {
@@ -44,7 +48,7 @@
 .header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: var(--space-1);
   padding: var(--space-1) var(--space-2);
   border-radius: calc(var(--border-radius) - 2px) calc(var(--border-radius) - 2px) 0 0;
   font-size: 10px;
@@ -53,8 +57,26 @@
   letter-spacing: 0.5px;
 }
 
+.dragHandle {
+  color: var(--gray-500);
+  font-size: 8px;
+  letter-spacing: -2px;
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
+  cursor: grab;
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+}
+
+.node:hover .dragHandle {
+  opacity: 1;
+}
+
 .level {
   color: var(--gray-800);
+  flex: 1;
 }
 
 .type {

--- a/src/components/nodes/TeamMemberNode.tsx
+++ b/src/components/nodes/TeamMemberNode.tsx
@@ -53,7 +53,6 @@ function TeamMemberNode({ data, selected }: TeamMemberNodeProps) {
       )}
 
       <div className={styles.header} style={{ backgroundColor: levelColor }}>
-        <span className={styles.dragHandle} title="Drag to move">⋮⋮</span>
         <span className={styles.level}>{levelName}</span>
         {/* Hide designer type for leadership/top-level roles or when not set */}
         {!isLeadership && typeAbbr && <span className={styles.type}>{typeAbbr}</span>}

--- a/src/components/nodes/TeamMemberNode.tsx
+++ b/src/components/nodes/TeamMemberNode.tsx
@@ -53,6 +53,7 @@ function TeamMemberNode({ data, selected }: TeamMemberNodeProps) {
       )}
 
       <div className={styles.header} style={{ backgroundColor: levelColor }}>
+        <span className={styles.dragHandle} title="Drag to move">⋮⋮</span>
         <span className={styles.level}>{levelName}</span>
         {/* Hide designer type for leadership/top-level roles */}
         {!isLeadership && <span className={styles.type}>{typeAbbr}</span>}

--- a/src/components/nodes/TeamMemberNode.tsx
+++ b/src/components/nodes/TeamMemberNode.tsx
@@ -55,8 +55,8 @@ function TeamMemberNode({ data, selected }: TeamMemberNodeProps) {
       <div className={styles.header} style={{ backgroundColor: levelColor }}>
         <span className={styles.dragHandle} title="Drag to move">⋮⋮</span>
         <span className={styles.level}>{levelName}</span>
-        {/* Hide designer type for leadership/top-level roles */}
-        {!isLeadership && <span className={styles.type}>{typeAbbr}</span>}
+        {/* Hide designer type for leadership/top-level roles or when not set */}
+        {!isLeadership && typeAbbr && <span className={styles.type}>{typeAbbr}</span>}
       </div>
 
       <div className={styles.content}>


### PR DESCRIPTION
## Summary
This PR introduces an interactive onboarding tour that guides new users through the key features of the design team map application. The tour is shown on first visit and can be skipped at any time, with progress persisted in localStorage.

## Key Changes

- **New Onboarding Component** (`src/components/Onboarding.tsx`): 
  - 4-step guided tour covering: adding members, editing cards, dragging to move, and connecting cards
  - Smart step progression that waits for required cards to be added before advancing
  - Pauses and resumes based on card count (e.g., if user deletes cards, tour pauses until they add more)
  - Completion state persisted in localStorage to show tour only once

- **Onboarding Styling** (`src/components/Onboarding.module.css`):
  - Positioned tooltips with directional arrows (top/bottom/left/right)
  - Smooth fade-in animation
  - Responsive positioning that keeps tooltips within viewport bounds

- **FlowChart Updates** (`src/components/FlowChart.tsx`):
  - Enhanced `fitView` logic to auto-fit canvas when cards are added during onboarding
  - Ensures newly added cards are visible without manual zoom/pan

- **UI/UX Improvements**:
  - Added `data-testid="add-member-btn"` to Toolbar for onboarding targeting
  - Updated TeamMemberNode cursor to `grab`/`grabbing` to indicate draggability
  - Enhanced handle hover states with size increase and color change
  - Fixed type abbreviation display to hide when not set

- **Version Bump**: Updated to v0.2.0

## Implementation Details

- Tour steps are defined with target selectors, titles, content, and positioning preferences
- Each step can specify a `minCards` requirement; the tour waits if conditions aren't met
- Uses localStorage keys: `design-team-map-onboarding-completed` and `design-team-map-onboarding-step`
- Tooltip positioning uses viewport-aware calculations to prevent overflow
- Includes comprehensive logging for debugging tour flow

https://claude.ai/code/session_01Kagt6bX1pXS5JnQZwn8MSu