### PR TITLE
Fix onboarding crash and refactor localStorage keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.1] - 2026-02-02
+
+### Fixed
+- **Onboarding Crash**: Fixed TypeError when selecting industry preset after clearing data
+  - Root cause: Stale `currentStep` in localStorage exceeded bounds when switching onboarding modes
+  - Added bounds clamping and defensive null checks
+
+### Changed
+- **Renamed localStorage Keys**: Onboarding keys renamed from `design-team-map-*` to `org-map-*`
+- **Clear Data Now Resets Onboarding**: `clearAll()` now clears onboarding state, giving users a fresh experience
+
+### Technical
+- Created shared constants file `src/constants/onboarding.ts`
+- Removed hardcoded localStorage key strings across components
+
 ## [1.0.0] - 2026-02-02
 
 ### Added

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,9 +8,9 @@ import Toast from './components/Toast';
 import { useStore } from './store/useStore';
 import Onboarding from './components/Onboarding';
 import styles from './App.module.css';
+import { ONBOARDING_MODE_KEY } from './constants/onboarding';
 
 const QUICKSTART_SEEN_KEY = 'org-mapper-quickstart-seen';
-const ONBOARDING_MODE_KEY = 'design-team-map-onboarding-mode';
 
 function App() {
   const nodes = useStore((state) => state.nodes);

--- a/src/components/FlowChart.tsx
+++ b/src/components/FlowChart.tsx
@@ -22,6 +22,7 @@ import {
   calculatePromotionEligibility,
   wouldCreateCircularReference,
 } from '../utils/calculations';
+import { ONBOARDING_COMPLETED_KEY } from '../constants/onboarding';
 import TeamMemberNode from './nodes/TeamMemberNode';
 import ReportingEdge from './edges/ReportingEdge';
 import styles from './FlowChart.module.css';
@@ -163,7 +164,7 @@ function FlowChartInner() {
   // Fit view when nodes are added
   useEffect(() => {
     const nodesIncreased = teamNodes.length > prevNodeCount.current;
-    const onboardingActive = !localStorage.getItem('design-team-map-onboarding-completed');
+    const onboardingActive = !localStorage.getItem(ONBOARDING_COMPLETED_KEY);
 
     if (isInitialMount.current && teamNodes.length > 0) {
       // Small delay to ensure nodes are rendered

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -6,10 +6,11 @@ import {
   trackOnboardingCompleted,
   trackOnboardingSkipped,
 } from '../utils/analytics';
-
-const ONBOARDING_KEY = 'design-team-map-onboarding-completed';
-const ONBOARDING_STEP_KEY = 'design-team-map-onboarding-step';
-const ONBOARDING_MODE_KEY = 'design-team-map-onboarding-mode';
+import {
+  ONBOARDING_COMPLETED_KEY,
+  ONBOARDING_STEP_KEY,
+  ONBOARDING_MODE_KEY,
+} from '../constants/onboarding';
 
 interface OnboardingStep {
   id: string;
@@ -101,7 +102,7 @@ export default function Onboarding({ mode: propMode }: OnboardingProps) {
 
   // Initialize onboarding on mount
   useEffect(() => {
-    const completed = localStorage.getItem(ONBOARDING_KEY);
+    const completed = localStorage.getItem(ONBOARDING_COMPLETED_KEY);
     if (completed) return;
 
     // Determine mode from prop or localStorage
@@ -155,7 +156,7 @@ export default function Onboarding({ mode: propMode }: OnboardingProps) {
 
   // Pause tour if cards are deleted and we no longer have enough
   useEffect(() => {
-    const completed = localStorage.getItem(ONBOARDING_KEY);
+    const completed = localStorage.getItem(ONBOARDING_COMPLETED_KEY);
     if (completed) return;
 
     // If tooltip is visible but we don't have enough cards anymore, pause
@@ -226,7 +227,7 @@ export default function Onboarding({ mode: propMode }: OnboardingProps) {
 
   const handleComplete = useCallback(() => {
     trackOnboardingCompleted(onboardingMode);
-    localStorage.setItem(ONBOARDING_KEY, 'true');
+    localStorage.setItem(ONBOARDING_COMPLETED_KEY, 'true');
     localStorage.removeItem(ONBOARDING_STEP_KEY);
     setIsVisible(false);
     setWaitingForCards(false);

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -112,7 +112,9 @@ export default function Onboarding({ mode: propMode }: OnboardingProps) {
 
     const modeSteps = getStepsForMode(effectiveMode);
     const savedStep = localStorage.getItem(ONBOARDING_STEP_KEY);
-    const stepNum = savedStep ? parseInt(savedStep, 10) : 0;
+    const parsedStep = savedStep ? parseInt(savedStep, 10) : 0;
+    // Clamp step to valid bounds to prevent out-of-bounds access when mode changes
+    const stepNum = Math.max(0, Math.min(parsedStep, modeSteps.length - 1));
     const stepMinCards = modeSteps[stepNum]?.minCards ?? 0;
     setCurrentStep(stepNum);
 
@@ -169,6 +171,7 @@ export default function Onboarding({ mode: propMode }: OnboardingProps) {
 
     const findTarget = () => {
       const step = steps[currentStep];
+      if (!step) return;
       const element = document.querySelector(step.target);
       if (element) {
         setTargetRect(element.getBoundingClientRect());
@@ -239,6 +242,9 @@ export default function Onboarding({ mode: propMode }: OnboardingProps) {
   if (!isVisible) return null;
 
   const step = steps[currentStep];
+  // Defensive check: if step is undefined (shouldn't happen after bounds fix), don't render
+  if (!step) return null;
+
   const { style: tooltipStyle, arrowOffset } = getTooltipPosition(targetRect, step.position);
   const arrowClass = styles[`arrow${step.position.charAt(0).toUpperCase() + step.position.slice(1)}`];
 

--- a/src/components/panels/SettingsPanel.tsx
+++ b/src/components/panels/SettingsPanel.tsx
@@ -573,7 +573,7 @@ export default function SettingsPanel({ onOpenQuickstart }: SettingsPanelProps) 
             <div className={styles.section}>
               <div className={styles.aboutHeader}>
 <h3 className={styles.aboutTitle}>MapYour.Org</h3>
-                <span className={styles.version}>v1.0.0</span>
+                <span className={styles.version}>v1.0.1</span>
               </div>
 
               <p className={styles.aboutDesc}>

--- a/src/constants/onboarding.ts
+++ b/src/constants/onboarding.ts
@@ -1,0 +1,11 @@
+// Onboarding localStorage keys
+export const ONBOARDING_COMPLETED_KEY = 'org-map-onboarding-completed';
+export const ONBOARDING_STEP_KEY = 'org-map-onboarding-step';
+export const ONBOARDING_MODE_KEY = 'org-map-onboarding-mode';
+
+// Helper to clear all onboarding state from localStorage
+export function clearOnboardingState(): void {
+  localStorage.removeItem(ONBOARDING_COMPLETED_KEY);
+  localStorage.removeItem(ONBOARDING_STEP_KEY);
+  localStorage.removeItem(ONBOARDING_MODE_KEY);
+}

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -12,6 +12,7 @@ import type {
 import { DEFAULT_SETTINGS } from '../types';
 import { calculateAutoArrangePositions, wouldCreateCircularReference } from '../utils/calculations';
 import { trackCardCreated, trackCardDeleted, trackCardConverted, trackDataCleared } from '../utils/analytics';
+import { clearOnboardingState } from '../constants/onboarding';
 
 interface TeamMapState {
   // Data
@@ -305,6 +306,7 @@ export const useStore = create<TeamMapState>()(
           selectedNodeId: null,
           isPanelOpen: false,
         });
+        clearOnboardingState();
         trackDataCleared();
       },
     }),


### PR DESCRIPTION
## Summary
This PR fixes a critical crash in the onboarding flow when switching between onboarding modes and introduces a centralized constants file for onboarding-related localStorage keys. The crash occurred when stale `currentStep` values exceeded bounds after mode changes.

## Key Changes

- **Fixed onboarding crash**: Added bounds clamping to `currentStep` initialization and defensive null checks when accessing step data
  - Root cause: Stale localStorage step values could exceed array bounds when switching onboarding modes
  - Solution: Clamp parsed step to valid range `[0, modeSteps.length - 1]` and add null checks before accessing step properties

- **Refactored localStorage keys**: Created `src/constants/onboarding.ts` to centralize all onboarding-related constants
  - Renamed keys from `design-team-map-*` to `org-map-*` for consistency
  - Removed hardcoded strings across `App.tsx`, `Onboarding.tsx`, and `FlowChart.tsx`
  - Added `clearOnboardingState()` helper function for clean state management

- **Enhanced data clearing**: `clearAll()` in the store now resets onboarding state via `clearOnboardingState()`
  - Gives users a fresh onboarding experience when they clear their data

- **Version bump**: Updated to v1.0.1

## Implementation Details

- Bounds clamping uses `Math.max(0, Math.min(parsedStep, modeSteps.length - 1))` to safely constrain step values
- Added defensive checks (`if (!step) return;`) in tooltip positioning and render logic to prevent undefined access
- All onboarding constants now exported from single source of truth for easier maintenance

https://claude.ai/code/session_01CYjyGbwEpujLbRXmHsQD5K